### PR TITLE
Fix let form

### DIFF
--- a/hgignore-mode.el
+++ b/hgignore-mode.el
@@ -88,7 +88,7 @@
   ;; set up font-lock
   (setq font-lock-defaults (list hgignore--keywords))
   ;; syntax table
-  (let (table hgignore-mode-syntax-table)
+  (let ((table hgignore-mode-syntax-table))
     (modify-syntax-entry ?\# "<" table)
     (modify-syntax-entry ?\n ">" table))
   ;; comment/uncomment correctly


### PR DESCRIPTION
This also fixes the following byte-compile warning

```
hgignore-mode.el:91:9: Warning: Variable ‘table’ left uninitialized
```